### PR TITLE
Fix-nil-error

### DIFF
--- a/lua/weapons/m9k_damascus.lua
+++ b/lua/weapons/m9k_damascus.lua
@@ -38,7 +38,7 @@ function SWEP:PrimaryAttack() -- Stabby stab stab
 			local Dur = vm:SequenceDuration()
 
 			timer.Create("M9k_MMM_Grenade_Grenadethrow" .. self.OurIndex,0.1,1,function() -- Attack damage is delayed!
-                if not IsValid( self ) then return end
+				if not IsValid( self ) then return end
 
 				if SERVER then
 					local Pos = self.Owner:EyePos()

--- a/lua/weapons/m9k_damascus.lua
+++ b/lua/weapons/m9k_damascus.lua
@@ -38,6 +38,8 @@ function SWEP:PrimaryAttack() -- Stabby stab stab
 			local Dur = vm:SequenceDuration()
 
 			timer.Create("M9k_MMM_Grenade_Grenadethrow" .. self.OurIndex,0.1,1,function() -- Attack damage is delayed!
+                if not IsValid( self ) then return end
+
 				if SERVER then
 					local Pos = self.Owner:EyePos()
 					local tTrace = util.TraceHull({


### PR DESCRIPTION
```
addons/cfc_m9kr/lua/weapons/m9k_damascus.lua:80: attempt to concatenate field 'OurIndex' (a nil value)
  1. unknown - addons/cfc_m9kr/lua/weapons/m9k_damascus.lua:80
   0.  unknown - addons/cfc_m9kr/lua/weapons/m9k_damascus.lua:80
```
It tries to index `self.OurIndex` which can only be nil if the ent isn't valid anymore (OurIndex is set on ent init in the base)
